### PR TITLE
MM-2020: Upgrade version to 1.1.9 and improve pointer event handling …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sarc-mediq/react-sketch-canvas",
-  "version": "1.1.7",
+  "version": "1.1.9",
   "description": "react-sketch-canvas - Freehand vector drawing tool for React using SVG as canvas",
   "author": "SARC-MedIQ",
   "homepage": "https://github.com/SARC-MedIQ/react-sketch-canvas#readme",

--- a/src/ReactSketchCanvas/index.tsx
+++ b/src/ReactSketchCanvas/index.tsx
@@ -149,7 +149,8 @@ export const ReactSketchCanvas = React.forwardRef<
     return drawMode === CanvasMode.pen || drawMode === CanvasMode.eraser
   }
 
-  const liftUpdatedStateUp = React.useCallback((paths: CanvasPath[]): void => {
+  const liftUpdatedStateUp = React.useCallback(
+    (paths: CanvasPath[]): void => {
       const lastStroke = paths.slice(-1)?.[0] ?? null
 
       if (lastStroke === null) {
@@ -243,9 +244,14 @@ export const ReactSketchCanvas = React.forwardRef<
     }
   }
 
-  const loadTexts = (texts: CanvasText[], fromSize?: Size, toSize?: Size): void => {
+  const loadTexts = (
+    texts: CanvasText[],
+    fromSize?: Size,
+    toSize?: Size
+  ): void => {
     if (fromSize) {
-      const targetSize = toSize ?? currentSizeRef.current ?? svgCanvas.current?.size
+      const targetSize =
+        toSize ?? currentSizeRef.current ?? svgCanvas.current?.size
       if (targetSize) {
         texts = scaleTexts(texts, fromSize, targetSize)
         currentSizeRef.current = targetSize

--- a/src/ReactSketchCanvas/index.tsx
+++ b/src/ReactSketchCanvas/index.tsx
@@ -149,8 +149,7 @@ export const ReactSketchCanvas = React.forwardRef<
     return drawMode === CanvasMode.pen || drawMode === CanvasMode.eraser
   }
 
-  const liftUpdatedStateUp = React.useCallback(
-    (paths: CanvasPath[]): void => {
+  const liftUpdatedStateUp = React.useCallback((paths: CanvasPath[]): void => {
       const lastStroke = paths.slice(-1)?.[0] ?? null
 
       if (lastStroke === null) {
@@ -244,14 +243,9 @@ export const ReactSketchCanvas = React.forwardRef<
     }
   }
 
-  const loadTexts = (
-    texts: CanvasText[],
-    fromSize?: Size,
-    toSize?: Size
-  ): void => {
+  const loadTexts = (texts: CanvasText[], fromSize?: Size, toSize?: Size): void => {
     if (fromSize) {
-      const targetSize =
-        toSize ?? currentSizeRef.current ?? svgCanvas.current?.size
+      const targetSize = toSize ?? currentSizeRef.current ?? svgCanvas.current?.size
       if (targetSize) {
         texts = scaleTexts(texts, fromSize, targetSize)
         currentSizeRef.current = targetSize


### PR DESCRIPTION
Linked findings PR: https://github.com/SARC-MedIQ/findings/pull/452

- Added referenceSize prop to explicitly specify reference dimensions (e.g., original image size) with fallback to backgroundImageSize
- Refactored onChange callback handling - Moved all onChange calls to a single useEffect that runs outside render cycle with fresh state values
- Enhanced loadPaths and loadTexts functions - Added explicit fromSize and toSize parameters for precise scaling from reference space to canvas space
- Added getCanvasDimensions helper function - Uses requestAnimationFrame to get accurate DOM dimensions with proper fallback chain
- Updated addPath and addText methods - Now use getCanvasDimensions for accurate size retrieval and pass both reference and current dimensions
- Improved liftUpdatedStateUp callback - Now accepts paths as parameter instead of using closure to prevent stale state issues



## How It Works Now
- Coordinate Space Management:
- Input points are expected in reference space (original image dimensions)
- Stored internally in reference space for consistency
- Automatically scaled to current canvas space for rendering
- Re-scaled correctly when canvas resizes
- State Change Flow:
- User Action → State Update → useEffect → onChange with Fresh State → Parent Update